### PR TITLE
.travis.yml: Remove unused sudo keyword

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
     - $PWD/wheelhouse
     - $HOME/.cache/pip
 dist: xenial
-sudo: false
 env:
   global:
     - PIP_FIND_LINKS=$PWD/wheelhouse


### PR DESCRIPTION
This is not required or used anymore, see [1].

[1]: https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures