### PR TITLE
Fix #11: Change app.add_javascript and app.add_stylesheet

### DIFF
--- a/sphinxcontrib/images.py
+++ b/sphinxcontrib/images.py
@@ -233,10 +233,16 @@ def install_backend_static_files(app, env):
 
         copyfile(source_file_path, dest_file_path)
 
-        if dest_file_path.endswith('.js'):
-            app.add_javascript(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
-        elif dest_file_path.endswith('.css'):
-            app.add_stylesheet(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
+        if sphinx.__version__ > '2':
+            if dest_file_path.endswith('.js'):
+                app.add_js_file(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
+            elif dest_file_path.endswith('.css'):
+                app.add_css_file(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
+        else:
+            if dest_file_path.endswith('.js'):
+                app.add_javascript(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
+            elif dest_file_path.endswith('.css'):
+                app.add_stylesheet(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
 
 
 def download_images(app, env):

--- a/sphinxcontrib/images.py
+++ b/sphinxcontrib/images.py
@@ -233,16 +233,10 @@ def install_backend_static_files(app, env):
 
         copyfile(source_file_path, dest_file_path)
 
-        if sphinx.__version__ > '2':
-            if dest_file_path.endswith('.js'):
-                app.add_js_file(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
-            elif dest_file_path.endswith('.css'):
-                app.add_css_file(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
-        else:
-            if dest_file_path.endswith('.js'):
-                app.add_javascript(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
-            elif dest_file_path.endswith('.css'):
-                app.add_stylesheet(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
+        if dest_file_path.endswith('.js'):
+            app.add_js_file(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
+        elif dest_file_path.endswith('.css'):
+            app.add_css_file(os.path.relpath(dest_file_path, STATICS_DIR_PATH))
 
 
 def download_images(app, env):


### PR DESCRIPTION
These two methods will disappear with Sphinx 4.0. New ones are available since Sphinx 1.8. This commit uses the new ones if Sphinx version is >= 2.0.