### PR TITLE
Change the thumbnail cursor 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/docs/source/_images
-/docs/build
+/docs/_images
+/docs/_build
 /.tox
 *~
 *pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,3 +7,4 @@ include sphinxcontrib_images_lightbox2/lightbox2/dist/js/lightbox-plus-jquery.mi
 include sphinxcontrib_images_lightbox2/lightbox2/dist/js/lightbox-plus-jquery.min.map
 include sphinxcontrib_images_lightbox2/lightbox2/dist/css/lightbox.css
 include sphinxcontrib_images_lightbox2/lightbox2-customize/jquery-noconflict.js
+include sphinxcontrib_images_lightbox2/lightbox2-customize/pointer.css

--- a/sphinxcontrib_images_lightbox2/lightbox2-customize/pointer.css
+++ b/sphinxcontrib_images_lightbox2/lightbox2-customize/pointer.css
@@ -1,0 +1,2 @@
+/* change the lightbox cursor */
+a[data-lightbox] {cursor: zoom-in;}

--- a/sphinxcontrib_images_lightbox2/lightbox2.py
+++ b/sphinxcontrib_images_lightbox2/lightbox2.py
@@ -11,7 +11,8 @@ class LightBox2(images.Backend):
         'lightbox2/dist/js/lightbox-plus-jquery.min.js',
         'lightbox2/dist/js/lightbox-plus-jquery.min.map',
         'lightbox2/dist/css/lightbox.css',
-        'lightbox2-customize/jquery-noconflict.js'
+        'lightbox2-customize/jquery-noconflict.js',
+        'lightbox2-customize/pointer.css'
     )
 
     def visit_image_node_html(self, writer, node):


### PR DESCRIPTION
- change the cursor from the link pointer to the zoom-in one. 
- when I built the doc, `_build` and `_image` folders were not ignored, I changed the `.gitignore` accordingly

Fix #28  