### PR TITLE
Ensure download destination directory exists

### DIFF
--- a/sphinxcontrib/images.py
+++ b/sphinxcontrib/images.py
@@ -250,6 +250,8 @@ def download_images(app, env):
             len(env.remote_images)):
 
         dst = os.path.join(env.srcdir, env.remote_images[src])
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+
         if not os.path.isfile(dst):
             logger.info('{} -> {} (downloading)'
                       .format(src, dst))


### PR DESCRIPTION
Otherwise, a FileNotFound exception will be raised on the open() call.
This issue may be somewhat related to Pull Request #23 I'm not sure.

It wasn't as simple as making the `env.srcdir`, as the `env.remote_images[src]` typically contains at least one folder stem. e.g., `'_video_thumbnail/657905289.jpg'`. This is why it takes the full `dst`, gets its parent directory, and makes the directory of that including its parents' leafs.

I've personally encountered this on readthedocs in a [poetry build environment](https://github.com/rlaphoenix/VSGAN/blob/3c64205db5ecda1996a2c5a93685feef05113dcf/.readthedocs.yaml#L7-L13=).
I can confirm the rtd environment did already have `env.srcdir` made, but not the further `_video_thumbnail/` folder from `env.remote_images[src]`.