### PR TITLE
Use non-deprecated alias for util.status_iterator

### DIFF
--- a/sphinxcontrib/images.py
+++ b/sphinxcontrib/images.py
@@ -29,9 +29,12 @@ except:
     from docutils.parsers.rst import Directive
 
 try:
-    from sphinx.util import status_iterator
+    from sphinx.util.display import status_iterator
 except ImportError:
-    pass
+    try:
+        from sphinx.util import status_iterator
+    except ImportError:
+        pass
 
 from sphinx.util.console import brown
 from sphinx.util.osutil import ensuredir


### PR DESCRIPTION
sphinx.util.status_iterator alias has been deprecated since sphinx 6.1 and will be removed in sphinx 8.0

See https://www.sphinx-doc.org/en/master/extdev/deprecated.html

The preferred access for status_iterator is sphinx.util.display.status_iterator. This commit adopts the new sphinx API and then falls back on the older API access since this plugin supports older versions of sphinx.